### PR TITLE
Customize sessions controller, disable CSRF token validation

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,7 @@
+class SessionsController < Devise::SessionsController
+  # Disable CSRF token verification, as this controller is used for remote login and logout.
+  # It's not necessary, as there's no session before user signs in and we don't care about session when we log out.
+  # However there's warning each time. Also, Rails can be configured to trigger an exception when CSRF token validation
+  # fails, so better to handle that correctly.
+  skip_before_filter :verify_authenticity_token
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_scope :user do
-    post '/remote_login', :to => 'devise/sessions#create', :as => :remote_login
-    post '/remote_logout', :to => 'devise/sessions#destroy', :as => :remote_logout
+    post '/remote_login', :to => 'sessions#create', :as => :remote_login
+    post '/remote_logout', :to => 'sessions#destroy', :as => :remote_logout
   end
   get '/verify_cc_token', :to => 'remote_auth#verify_cc_token', :as => :verify_cc_token
 end


### PR DESCRIPTION
It isn't 100% necessary, as even when CSRF token check is failing, things work fine. But I think it makes sense to be safe and avoid possible issues in the future (there's a comment in the code).