### PR TITLE
Update devise dependency version

### DIFF
--- a/cc_portal_remote_auth.gemspec
+++ b/cc_portal_remote_auth.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   # Make sure to match versions with the rails portal
   s.add_dependency "rails", "~> 3.2.11"
-  s.add_dependency "devise", "~> 2.1.0"
+  s.add_dependency "devise", "~> 3.1.0"
   # s.add_dependency "jquery-rails"
 
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
This PR is a prerequisite to update devise in rigse. This updates the devise dependency to ~> 3.1.0.